### PR TITLE
feature: Add module version constraints. Limit gke service account names

### DIFF
--- a/infrastructure/gke-for-educates/01-vpc.tf
+++ b/infrastructure/gke-for-educates/01-vpc.tf
@@ -1,18 +1,7 @@
-data "google_compute_zones" "this" {
-  region  = var.region
-  project = var.project_id
-}
-
 locals {
   network_ip_cidr_range  = "10.0.0.0/24"
   subnet_types           = ["pods", "services"]
   subnets_ip_cidr_ranges = ["10.1.0.0/16", "10.2.0.0/20"]
-  zones                  = data.google_compute_zones.this.names
-  zone                   = slice(local.zones, 0, 1)
-}
-
-output "zones" {
-  value = local.zone
 }
 
 module "vpc" {

--- a/infrastructure/gke-for-educates/outputs.tf
+++ b/infrastructure/gke-for-educates/outputs.tf
@@ -14,7 +14,11 @@ output "gke" {
 
 output "kubeconfig_file" {
   value       = local.kubeconfig_filename
-  description = "kubeconfig full path for the AWS EKS cluster"
+  description = "kubeconfig full path for the GKE cluster"
+}
+
+output "zones" {
+  value = local.zone
 }
 
 # # Some inspiration from: https://github.com/TykTechnologies/tyk-performance-testing/blob/main/modules/clouds/aws/main.tf

--- a/infrastructure/gke-for-educates/variables.tf
+++ b/infrastructure/gke-for-educates/variables.tf
@@ -15,11 +15,11 @@ variable "region" {
 variable "kubernetes_version" {
   description = "Version of kubernetes cluster to create"
   type        = string
-  default     = "1.32"
+  default     = "1.33"
 
   validation {
-    condition     = contains(["1.30", "1.31", "1.32"], var.kubernetes_version)
-    error_message = "kubernetes_version must be between 1.30 and 1.32"
+    condition     = contains(["1.30", "1.31", "1.32", "1.33"], var.kubernetes_version)
+    error_message = "kubernetes_version must be between 1.30 and 1.33"
   }
 }
 

--- a/infrastructure/token-sa-kubeconfig/versions.tf
+++ b/infrastructure/token-sa-kubeconfig/versions.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     kubernetes = {
       source = "hashicorp/kubernetes"
-      #version = "2.31.0"
+      version = "~> 2.31"
     }
     local = {
       source = "hashicorp/local"
-#      version = "2.5.2"
+      version = "~> 2.5"
     }
     time = {
       source = "hashicorp/time"
-#      version = "0.11.2"
+      version = "~> 0.11"
     }
   }
 }

--- a/platform/educates/20-educates-app.tf
+++ b/platform/educates/20-educates-app.tf
@@ -114,8 +114,8 @@ locals {
           zone = "${var.gcp_config.dns_zone}"
         }
         workloadIdentity = {
-          external-dns = "${var.gcp_config.cluster_name}-external-dns@${var.gcp_config.project}.iam.gserviceaccount.com"
-          cert-manager = "${var.gcp_config.cluster_name}-cert-manager@${var.gcp_config.project}.iam.gserviceaccount.com"
+          external-dns = var.gcp_config.externaldns_service_account != "" ? var.gcp_config.externaldns_service_account : "${var.gcp_config.cluster_name}-ext-dns@${var.gcp_config.project}.iam.gserviceaccount.com"
+          cert-manager = var.gcp_config.certmanager_service_account != "" ? var.gcp_config.certmanager_service_account : "${var.gcp_config.cluster_name}-cert-mgr@${var.gcp_config.project}.iam.gserviceaccount.com"
         }
       }
     }

--- a/platform/educates/README.md
+++ b/platform/educates/README.md
@@ -17,6 +17,15 @@ Either use provided terraform variables and by selecting the `infrastructure_pro
 you can provide a a variable `educates_config.config_file` with Educates Configuration format that will be merged with the default module configuration
 (overriding those values that overlap), or will replace the complete configuration if `educates_config.config_is_to_be_merged` is `False`.
 
+### GCP Configuration
+
+When using `infrastructure_provider = "gcp"`, the module can automatically configure workload identity for cert-manager and external-dns services:
+
+- `certmanager_service_account`: Optional. The full email of the Google Service Account for cert-manager workload identity. If not provided, defaults to `{cluster_name}-cert-mgr@{project}.iam.gserviceaccount.com`
+- `externaldns_service_account`: Optional. The full email of the Google Service Account for external-dns workload identity. If not provided, defaults to `{cluster_name}-ext-dns@{project}.iam.gserviceaccount.com`
+
+These variables allow the module to use the actual service account emails from the GKE infrastructure module, ensuring consistency when service account names are truncated for length constraints.
+
 ## Requirements
 
 | Name | Version |
@@ -59,7 +68,7 @@ you can provide a a variable `educates_config.config_file` with Educates Configu
 | <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | TODO: Make these into a struct #### AWS #### | <pre>object({<br/>    account_id   = string<br/>    cluster_name = string<br/>    region       = string<br/>    dns_zone     = string<br/>  })</pre> | <pre>{<br/>  "account_id": "",<br/>  "cluster_name": "",<br/>  "dns_zone": "",<br/>  "region": ""<br/>}</pre> | no |
 | <a name="input_educates_app"></a> [educates\_app](#input\_educates\_app) | n/a | <pre>object({<br/>    namespace   = optional(string, "package-installs")<br/>    sync_period = optional(string, "8760h0m0s")<br/>  })</pre> | `{}` | no |
 | <a name="input_educates_config"></a> [educates\_config](#input\_educates\_config) | n/a | <pre>object({<br/>    installer_oci_image    = optional(string, "ghcr.io/educates/educates-installer")<br/>    version                = optional(string, "3.3.2")<br/>    config_file            = optional(string, "educates-app-config.yaml")<br/>    config_is_to_be_merged = optional(bool, true)<br/>    install                = optional(bool, true)<br/>  })</pre> | `{}` | no |
-| <a name="input_gcp_config"></a> [gcp\_config](#input\_gcp\_config) | #### GCP #### | <pre>object({<br/>    cluster_name = string<br/>    project      = string<br/>    dns_zone     = string<br/>  })</pre> | <pre>{<br/>  "cluster_name": "",<br/>  "dns_zone": "",<br/>  "project": ""<br/>}</pre> | no |
+| <a name="input_gcp_config"></a> [gcp\_config](#input\_gcp\_config) | #### GCP #### | <pre>object({<br/>    cluster_name                = string<br/>    project                     = string<br/>    dns_zone                    = string<br/>    certmanager_service_account = optional(string, "")<br/>    externaldns_service_account = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "certmanager_service_account": "",<br/>  "cluster_name": "",<br/>  "dns_zone": "",<br/>  "externaldns_service_account": "",<br/>  "project": ""<br/>}</pre> | no |
 | <a name="input_infrastructure_provider"></a> [infrastructure\_provider](#input\_infrastructure\_provider) | Infrastructure provider | `string` | n/a | yes |
 | <a name="input_wildcard_domain"></a> [wildcard\_domain](#input\_wildcard\_domain) | Wildcard domain to use for services deployed in the cluster | `string` | n/a | yes |
 

--- a/platform/educates/variables.tf
+++ b/platform/educates/variables.tf
@@ -63,13 +63,17 @@ variable "aws_config" {
 #####
 variable "gcp_config" {
   type = object({
-    cluster_name = string
-    project      = string
-    dns_zone     = string
+    cluster_name                = string
+    project                     = string
+    dns_zone                    = string
+    certmanager_service_account = optional(string, "")
+    externaldns_service_account = optional(string, "")
   })
   default = {
-    cluster_name = ""
-    project      = ""
-    dns_zone     = ""
+    cluster_name                = ""
+    project                     = ""
+    dns_zone                    = ""
+    certmanager_service_account = ""
+    externaldns_service_account = ""
   }
 }

--- a/root-modules/educates-on-eks/main.tf
+++ b/root-modules/educates-on-eks/main.tf
@@ -14,7 +14,8 @@ data "aws_iam_session_context" "current" {
 
 module "eks_for_educates" {
   source = "../../infrastructure/eks-for-educates"
-  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/eks-for-educates?ref=develop"
+  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/eks-for-educates"
+  # version = "~> 1.0"
 
   # We use terraform data sources to get the account_id
   aws_account_id     = data.aws_caller_identity.current.account_id
@@ -46,7 +47,8 @@ module "educates" {
   count = var.deploy_educates ? 1 : 0
 
   source = "../../platform/educates"
-# source           = "github.com/educates/educates-terraform-modules.git//platform/educates?ref=develop"
+  # source           = "github.com/educates/educates-terraform-modules.git//platform/educates"
+  # version = "~> 1.0"
   wildcard_domain = "${var.cluster_name}.${var.TLD}"
   educates_config = {
     version = var.educates_version
@@ -62,7 +64,8 @@ module "educates" {
 
 module "token-sa-kubeconfig" {
   source = "../../infrastructure/token-sa-kubeconfig"
-  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/token-sa-kubeconfig?ref=develop"
+  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/token-sa-kubeconfig"
+  # version = "~> 1.0"
 
   cluster = {
     name                   = var.cluster_name

--- a/root-modules/educates-on-gke/main.tf
+++ b/root-modules/educates-on-gke/main.tf
@@ -5,7 +5,8 @@ provider "google" {
 
 module "gke_for_educates" {
   source = "../../infrastructure/gke-for-educates"
-  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/gke-for-educates?ref=develop"
+  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/gke-for-educates"
+  # version = "~> 1.0"
 
   project_id         = var.project_id
   region             = var.region
@@ -31,7 +32,8 @@ module "educates" {
   count = var.deploy_educates ? 1 : 0
 
   source = "../../platform/educates"
-  # source           = "github.com/educates/educates-terraform-modules.git//platform/educates?ref=develop"
+  # source           = "github.com/educates/educates-terraform-modules.git//platform/educates"
+  # version = "~> 1.0"
   wildcard_domain = "${var.cluster_name}.${var.TLD}"
   educates_config = {
     version = var.educates_version
@@ -41,12 +43,15 @@ module "educates" {
     cluster_name = var.cluster_name
     project      = var.project_id
     dns_zone     = var.TLD
+    certmanager_service_account = module.gke_for_educates.gke.certmanager_service_account
+    externaldns_service_account = module.gke_for_educates.gke.externaldns_service_account
   }
 }
 
 module "token-sa-kubeconfig" {
   source = "../../infrastructure/token-sa-kubeconfig"
-  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/token-sa-kubeconfig?ref=develop"
+  # source = "github.com/educates/educates-terraform-modules.git//infrastructure/token-sa-kubeconfig"
+  # version = "~> 1.0"
 
   cluster = {
     name                   = var.cluster_name

--- a/root-modules/educates-on-gke/variables.tf
+++ b/root-modules/educates-on-gke/variables.tf
@@ -42,11 +42,11 @@ variable "node_groups" {
 variable "kubernetes_version" {
   description = "Version of kubernetes cluster to create"
   type        = string
-  default     = "1.32"
+  default     = "1.33"
 
   validation {
-    condition     = contains(["1.30", "1.31", "1.32"], var.kubernetes_version)
-    error_message = "kubernetes_version must be between 1.30 and 1.32"
+    condition     = contains(["1.30", "1.31", "1.32", "1.33"], var.kubernetes_version)
+    error_message = "kubernetes_version must be between 1.30 and 1.33"
   }
 }
 

--- a/root-modules/educates-on-gke/versions.tf
+++ b/root-modules/educates-on-gke/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
+      version = "~> 2.1"
     }
   }  
   required_version = ">= 1.5.0"


### PR DESCRIPTION
- Adding module version constraints to prevent modules to be identified as lagacy modules when used
- Adding limit of 30 characters to google service accounts for external_dns and cert-manager
- Reuse gke service accounts in educates module in sample root module for educates-on-gke