### PR TITLE
fix: Remove module configuration inline

### DIFF
--- a/infrastructure/gke-for-educates/versions.tf
+++ b/infrastructure/gke-for-educates/versions.tf
@@ -2,22 +2,22 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "6.28.0"
+      version = "6.47.0"
     }
 
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.6"
+      version = "4.1.0"
     }
 
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = "2.3.6"
+      version = "2.3.7"
     }
 
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "2.36.0"
+      version = "2.38.0"
     }    
   }
 }

--- a/infrastructure/token-sa-kubeconfig/10-kubernetes-resources.tf
+++ b/infrastructure/token-sa-kubeconfig/10-kubernetes-resources.tf
@@ -1,9 +1,3 @@
-provider "kubernetes" {
-  host                   = var.cluster.host
-  token                  = var.cluster.token
-  cluster_ca_certificate = var.cluster.cluster_ca_certificate
-}
-
 resource "kubernetes_namespace" "automation" {
   count = var.create_namespace ? 1 : 0
   metadata {

--- a/infrastructure/token-sa-kubeconfig/variables.tf
+++ b/infrastructure/token-sa-kubeconfig/variables.tf
@@ -4,7 +4,6 @@ variable "cluster" {
     name                   = string
     host                   = string
     cluster_ca_certificate = string
-    token                  = string
   })
 }
 

--- a/infrastructure/token-sa-kubeconfig/versions.tf
+++ b/infrastructure/token-sa-kubeconfig/versions.tf
@@ -2,15 +2,11 @@ terraform {
   required_providers {
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "~> 2.31"
+      version = "~> 2.38"
     }
     local = {
       source = "hashicorp/local"
       version = "~> 2.5"
-    }
-    time = {
-      source = "hashicorp/time"
-      version = "~> 0.11"
     }
   }
 }

--- a/root-modules/educates-on-gke/main.tf
+++ b/root-modules/educates-on-gke/main.tf
@@ -48,6 +48,15 @@ module "educates" {
   }
 }
 
+# Configure kubernetes provider for the 
+# token-sa-kubeconfig module
+provider "kubernetes" {
+  host                   = module.gke_for_educates.kubernetes.host
+  token                  = module.gke_for_educates.kubernetes.token
+  cluster_ca_certificate = module.gke_for_educates.kubernetes.cluster_ca_certificate
+}
+
+
 module "token-sa-kubeconfig" {
   source = "../../infrastructure/token-sa-kubeconfig"
   # source = "github.com/educates/educates-terraform-modules.git//infrastructure/token-sa-kubeconfig"

--- a/root-modules/educates-on-gke/versions.tf
+++ b/root-modules/educates-on-gke/versions.tf
@@ -1,9 +1,35 @@
 terraform {
   required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "6.47.0"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.1.0"
+    }
+
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "2.3.7"
+    }
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }    
+
+    local = {
+      source = "hashicorp/local"
+      version = "~> 2.5"
+    }
+
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.1"
+      version = "~> 2.1.3"
     }
+
   }  
   required_version = ">= 1.5.0"
 }


### PR DESCRIPTION
Having the kubernetes module configuration in token-sa-kubeconfig was preventing from proper reusability as was detected as legacy module and could not use the count or depends_on on it